### PR TITLE
withState: add callback as second optional argument of setter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ const enhance = createComposer<{ name: string }>
 # Static props
 
 ```.ts
-// .withState(staticProps: { [k: string]: any })
+// .withStatic(staticProps: { [k: string]: any })
 // .withDisplayName(name: string)
 ```
 

--- a/src/abstract.ts
+++ b/src/abstract.ts
@@ -248,7 +248,7 @@ export interface ComponentDecoratorBuilder<
     ) => Partial<T5> | null,
   ): ComponentDecoratorBuilder<
     TInitialProps,
-    TResultingProps & { [k in T3]: T5 } & { [k in T4]: (newState: T5) => T5 },
+    TResultingProps & { [k in T3]: T5 } & { [k in T4]: (updateFn: T5 | ((input: T5) => T5), callback?: () => void) => T5 },
     TOmittedProps,
     TStatic
   >
@@ -269,7 +269,7 @@ export interface ComponentDecoratorBuilder<
     ) => T5 | null,
   ): ComponentDecoratorBuilder<
     TInitialProps,
-    TResultingProps & { [k in T3]: T5 } & { [k in T4]: (newState: T5) => T5 },
+    TResultingProps & { [k in T3]: T5 } & { [k in T4]: (updateFn: T5 | ((input: T5) => T5), callback?: () => void) => T5 },
     TOmittedProps,
     TStatic
   >

--- a/src/bindings/recompose.ts
+++ b/src/bindings/recompose.ts
@@ -241,7 +241,7 @@ type StateProps<
   TStateName extends string,
   TStateUpdaterName extends string
 > = { [stateName in TStateName]: TState } &
-  { [stateUpdateName in TStateUpdaterName]: (state: TState) => TState }
+  { [stateUpdateName in TStateUpdaterName]: (updateFn: TState | (StateMapper<TState, TState>), callback?: () => void) => TState }
 
 interface WrappedState<TState> {
   readonly stateValue: TState

--- a/test/bindings/withState.test.tsx
+++ b/test/bindings/withState.test.tsx
@@ -30,6 +30,38 @@ describe('ComponentDecoratorBuilder::withState()', () => {
     assert.strictEqual(container.innerHTML, '<div>Ahoj Bobe!</div>')
   })
 
+  it('it allows to use a mapper function in state setter', async () => {
+    const decorate = createComposer()
+      .withState('salutation', 'setSalute', 'Ahoj')
+      .build()
+
+    const Salutation = decorate(({ salutation, setSalute }) => {
+      if (salutation === 'Ahoj') setSalute(salute => salute + ' Bobe!')
+      return <div>{salutation}</div>
+    })
+
+    const container = await render(<Salutation />)
+    assert.strictEqual(container.innerHTML, '<div>Ahoj Bobe!</div>')
+  })
+
+  it('it calls callback after the state is set and the component is re-rendered', async () => {
+    const decorate = createComposer()
+      .withState('salutation', 'setSalute', '')
+      .build()
+
+    let callbackHasBeenCalled = false
+
+    const Salutation = decorate(({ salutation, setSalute }) => {
+      if (salutation === '') setSalute('Ahoj Bobe!', () => {
+        callbackHasBeenCalled = true
+      })
+      return <div>{salutation}</div>
+    })
+
+    await render(<Salutation />)
+    assert(callbackHasBeenCalled)
+  })
+
   // FIXME: come up with a better way how to test this
   it('it appends derived state', async () => {
     const decorate = createComposer()

--- a/test/typings/withState.ts
+++ b/test/typings/withState.ts
@@ -8,7 +8,7 @@ enhance(props => {
   // $ExpectType boolean
   props.isActive
 
-  // $ExpectType (newState: boolean) => boolean
+  // $ExpectType (updateFn: boolean | ((input: boolean) => boolean), callback?: (() => void) | undefined) => boolean
   props.setActive
 
   return null


### PR DESCRIPTION
This PR extends the definition of `withState`'s setter function to allow the missing functionality carried over from recompose:
1) Mapper function as first argument of the setter:
  ```js
  setCount(count => count + 1)
  ```
2) Callback as the second argument:
  ```js
  setCount(5, () =>
    console.log('Updated state and re-rendered component successfully!')
  )
  ```

This PR changes only the TypeScript type defs. The business logic stayed the same.